### PR TITLE
Fix broken Brazilian Portuguese link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cognitive load is what matters
 
-[For AI agents](https://github.com/zakirullin/cognitive-load/blob/main/README.agents.md) | [Blog](https://minds.md/zakirullin/cognitive) | [Chinese](https://github.com/zakirullin/cognitive-load/blob/main/README.zh-cn.md) | [Japanese](README.ja.md) | [Spanish](README.es.md) | [Korean](README.ko.md) | [Turkish](README.tr.md) | [Brazilian Portuguese](README.pt-br) | [Vietnamese](README.vi.md) | [Nepali](README.np.md)
+[For AI agents](https://github.com/zakirullin/cognitive-load/blob/main/README.agents.md) | [Blog](https://minds.md/zakirullin/cognitive) | [Chinese](https://github.com/zakirullin/cognitive-load/blob/main/README.zh-cn.md) | [Japanese](README.ja.md) | [Spanish](README.es.md) | [Korean](README.ko.md) | [Turkish](README.tr.md) | [Brazilian Portuguese](README.pt-br.md) | [Vietnamese](README.vi.md) | [Nepali](README.np.md)
 
 *It is a living document, last update: **June 2026.***  
 


### PR DESCRIPTION
The `Brazilian Portuguese` link in the language navigation row points to `README.pt-br`, which 404s. The actual file is `README.pt-br.md`, and every sibling translation link (`README.ja.md`, `README.es.md`, etc.) uses the `.md` extension.

This adds the missing `.md` so the link resolves correctly.