### PR TITLE
Fix missing word and apostrophe inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The engineers on the frontend use backend API to implement login functionality. 
 `403` is for not enough access // `🧠++`  
 `418` is for banned users // `🧠+++`  
 
-Frontend developers would (hopefully) introduce some kind `numeric status -> meaning` dictionary on their side, so that subsequent generations of contributors wouldn't have to recreate this mapping in their brains.
+Frontend developers would (hopefully) introduce some kind of `numeric status -> meaning` dictionary on their side, so that subsequent generations of contributors wouldn't have to recreate this mapping in their brains.
 
 Then QA engineers come into play:
 "Hey, I got `403` status, is that expired token or not enough access?"
@@ -277,7 +277,7 @@ There is a certain engineering excitement about all this stuff.
 
 I myself was a passionate advocate of Hexagonal/Onion Architecture for years. I used it here and there and encouraged other teams to do so. The complexity of our projects went up, the sheer number of files alone had doubled. It felt like we were writing a lot of glue code. On ever changing requirements we had to make changes across multiple layers of abstractions, it all became tedious. `🤯`
 
-**Abstraction is supposed to hide complexity, here it just adds [indirection](https://fhur.me/posts/2024/thats-not-an-abstraction).** Jumping from call to call to read along and figure out what goes wrong and what is missing is a vital requirement to quickly solve a problem. With this architecture’s layer uncoupling it requires an exponential factor of extra, often disjointed, traces to get to the point where the failure occurs. Every such trace takes space in our limited working memory. `🤯`  
+**Abstraction is supposed to hide complexity, here it just adds [indirection](https://fhur.me/posts/2024/thats-not-an-abstraction).** Jumping from call to call to read along and figure out what goes wrong and what is missing is a vital requirement to quickly solve a problem. With this architecture's layer uncoupling it requires an exponential factor of extra, often disjointed, traces to get to the point where the failure occurs. Every such trace takes space in our limited working memory. `🤯`  
 
 <div align="center">
   <img src="/img/layers.png" alt="Layers" width="400">


### PR DESCRIPTION
Two small copy fixes:

1. **Missing word** — "introduce some kind `numeric status -> meaning` dictionary" → "some kind **of** `numeric status -> meaning` dictionary".
2. **Apostrophe consistency** — "architecture’s layer uncoupling" used a curly apostrophe (’) while the rest of the document uses straight apostrophes ('). Changed it to a straight apostrophe to match.

No content or meaning changes.